### PR TITLE
Add Linux build instructions and release script

### DIFF
--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+Target="thumbv8m.main-none-eabihf"
+Profile="release"
+BinName="msense-firmware"
+Features=("rev_1_3_2" "rev_2_0" "devboard")
+
+usage() {
+  echo "Usage: $0 [-t target] [-p profile] [-b binname] [-f feature1,feature2,...]" >&2
+  exit 1
+}
+
+while getopts "t:p:b:f:" opt; do
+  case $opt in
+    t) Target=$OPTARG ;;
+    p) Profile=$OPTARG ;;
+    b) BinName=$OPTARG ;;
+    f) IFS=',' read -r -a Features <<<"$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+if [[ -n $(git status --porcelain) ]]; then
+  echo "Working tree is dirty. Commit or stash first." >&2
+  exit 1
+fi
+
+get_version() {
+  cargo metadata --format-version 1 --no-deps | \
+    jq -r --arg name "$BinName" '.packages[] | select(.name==$name) | .version'
+}
+
+Ver=$(get_version)
+Tag="v$Ver"
+
+if gh release view "$Tag" >/dev/null 2>&1; then
+  echo "A release for tag $Tag already exists."
+  echo "[O]verwrite assets  |  [B]ump patch version  |  [Q]uit"
+  read -r -p "Choose O / B / Q: " choice
+  case "${choice^^}" in
+    O) echo "Will overwrite assets after build." ;;
+    B)
+      echo "Running cargo-release patch..."
+      cargo release patch --no-publish --no-tag --no-push --no-confirm --execute
+      Ver=$(get_version)
+      Tag="v$Ver"
+      echo "Version bumped to $Ver (tag $Tag)"
+      ;;
+    *) echo "Aborted by user." ; exit 1 ;;
+  esac
+fi
+
+BuildDir="target/$Target/$Profile"
+mkdir -p "$BuildDir"
+Artifacts=()
+
+for F in "${Features[@]}"; do
+  echo "==> Building with feature $F"
+  cargo build --$Profile --target "$Target" --features "$F"
+  dst="$BuildDir/${BinName}_${F}_${Ver}.elf"
+  cp "$BuildDir/$BinName" "$dst"
+  Artifacts+=("$dst")
+done
+
+if ! git tag -l "$Tag" >/dev/null 2>&1; then
+  git tag -a "$Tag" -m "msense-firmware $Tag"
+  git push origin "$Tag"
+fi
+
+if gh release view "$Tag" >/dev/null 2>&1; then
+  echo "Uploading assets to existing release $Tag ..."
+  gh release upload "$Tag" "${Artifacts[@]}" --clobber
+else
+  echo "Creating new release $Tag ..."
+  gh release create "$Tag" "${Artifacts[@]}" \
+    --title "msense-firmware $Tag" \
+    --notes "Autobuild for $Tag" \
+    --latest
+fi
+
+echo "Release $Tag published with ${#Artifacts[@]} binaries."

--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,33 @@
-#
-Msense NRF9160 
+# Msense NRF9160
 
-# Firmwarefor the Msense NRF9160
-This is the firmware for the Msense NRF9160 project
 Firmware for the msense NRF9160, a project to build a low-cost, open-source methane sensor using the Nordic NRF9160 and Figaro TGS8410 low power methane sensor.
 
-The program communicates over LTE-m with cbor encoded data through mtls tcp steams to a self hosted server. 
+The program communicates over LTE-m with CBOR encoded data through mTLS TCP steams to a self hosted server.
 
-before building, add a .env with your endpoint HOST_ADDRESS variable
+Before building, add a `.env` with your endpoint `HOST_ADDRESS` variable.
 
-Run build_and_release.ps1 to release to github
+Run `build_and_release.ps1` to release to GitHub. For Linux, use `./build_and_release.sh`.
+
+## Environment setup (Linux)
+
+1. Install Rust and Cargo via [rustup](https://rustup.rs/).
+2. Add the target:
+   ```bash
+   rustup target add thumbv8m.main-none-eabihf
+   ```
+3. Install the LLVM tools component:
+   ```bash
+   rustup component add llvm-tools
+   ```
+4. Install an ARM cross-compiler (Debian/Ubuntu):
+   ```bash
+   sudo apt-get update
+   sudo apt-get install gcc-arm-none-eabi
+   ```
+5. Build the firmware using the `devboard` feature:
+   ```bash
+   cargo build --features devboard
+   ```
 
 ## Building on Windows-amd64 (Windows OS)
 
@@ -73,3 +91,4 @@ choco install msys2
 </details>
 
 ## Building using the Nix package manager
+


### PR DESCRIPTION
## Summary
- document Linux build environment and usage
- add Bash build_and_release script for Linux

## Testing
- `cargo build --features devboard`


------
https://chatgpt.com/codex/tasks/task_e_689a26212c6c8320954c84abdefc81e5